### PR TITLE
Allow customization of TextAppearance in Title and Item Title with custom styles.

### DIFF
--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -3,6 +3,8 @@
 
     <declare-styleable name="BottomSheet">
         <attr name="bottomSheetStyle" format="reference"/>
+        <attr name="bsListItemTitleTextStyle" format="reference"/>
+        <attr name="bsTitleTextStyle" format="reference"/>
         <attr name="dialogBackground" format="color|reference" />
         <attr name="listSelector" format="color|reference" />
         <attr name="drawSelectorOnTop" format="boolean" />

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -21,6 +21,8 @@
         <item name="drawSelectorOnTop">false</item>
         <item name="dividerColor">@color/bs_divider_color</item>
         <item name="numColumns">@integer/bs_grid_colum</item>
+        <item name="bsListItemTitleTextStyle">@style/Text.Title</item>
+        <item name="bsTitleTextStyle">@style/Text.Headline</item>
     </style>
 
     <style name="BottomSheet.Dialog.Dark" parent="BottomSheet.Dialog">
@@ -69,7 +71,7 @@
         <item name="android:layout_marginRight">16dp</item>
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:textAppearance">@style/Text.Headline</item>
+        <item name="android:textAppearance">?bsTitleTextStyle</item>
         <item name="android:gravity">center_vertical</item>
     </style>
 
@@ -94,7 +96,7 @@
 
     <style name="BottomSheet.List.Item.Title">
         <item name="android:layout_marginLeft">16dp</item>
-        <item name="android:textAppearance">@style/Text.Title</item>
+        <item name="android:textAppearance">?bsListItemTitleTextStyle</item>
     </style>
 
     <style name="BottomSheet.List.Divider">


### PR DESCRIPTION
`Added two attributes for Title and Item Title style. Uses defaults, but can be overwritten in a custom BottomSheet.Dialog style.`

Hi, I'm using this library in my proyect. It's very nice (thanks for it), but I needed to tweak some styles. 
I added two customizable style attributes to set the text style in list items and title.

A lot more custom attributes could be added in order to further customize the looks of the Bottom Sheet, but for now I only needed those two. If you like the solution I would be glad to keep adding more custom attributes.

I hope you find it useful.
