### PR TITLE
fix typos and add methods to set icons on menu items after they have been created

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".ListAcitivty"/>
+        <activity android:name=".ListActivity"/>
 
         </application>
 </manifest>

--- a/example/src/main/java/com/cocosw/bottomsheet/example/ListActivity.java
+++ b/example/src/main/java/com/cocosw/bottomsheet/example/ListActivity.java
@@ -29,7 +29,7 @@ import java.util.List;
  * Project: gradle
  * Created by LiaoKai(soarcn) on 2014/9/22.
  */
-public class ListAcitivty extends ActionBarActivity implements AdapterView.OnItemClickListener {
+public class ListActivity extends ActionBarActivity implements AdapterView.OnItemClickListener {
 
     private CocoQuery q;
     private int action;
@@ -94,7 +94,7 @@ public class ListAcitivty extends ActionBarActivity implements AdapterView.OnIte
                 sheet = new BottomSheet.Builder(this).icon(getRoundedBitmap(R.drawable.icon)).title("To " + adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position),which);
+                        ListActivity.this.onClick(adapter.getItem(position),which);
                     }
                 }).build();
                 break;
@@ -102,7 +102,7 @@ public class ListAcitivty extends ActionBarActivity implements AdapterView.OnIte
                 sheet = new BottomSheet.Builder(this).sheet(R.menu.noicon).listener(new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position), which);
+                        ListActivity.this.onClick(adapter.getItem(position), which);
                     }
                 }).build();
                 break;
@@ -111,7 +111,7 @@ public class ListAcitivty extends ActionBarActivity implements AdapterView.OnIte
                 sheet = new BottomSheet.Builder(this).darkTheme().title("To " + adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position),which);
+                        ListActivity.this.onClick(adapter.getItem(position),which);
                     }
                 }).build();
                 break;
@@ -119,7 +119,7 @@ public class ListAcitivty extends ActionBarActivity implements AdapterView.OnIte
                 sheet = new BottomSheet.Builder(this).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position),which);
+                        ListActivity.this.onClick(adapter.getItem(position),which);
                     }
                 }).grid().build();
                 break;
@@ -127,7 +127,7 @@ public class ListAcitivty extends ActionBarActivity implements AdapterView.OnIte
                 sheet = new BottomSheet.Builder(this,R.style.BottomSheet_StyleDialog).title("To "+adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position),which);
+                        ListActivity.this.onClick(adapter.getItem(position),which);
                     }
                 }).build();
                 break;
@@ -135,7 +135,7 @@ public class ListAcitivty extends ActionBarActivity implements AdapterView.OnIte
                 sheet = new BottomSheet.Builder(this).title("To "+adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position),which);
+                        ListActivity.this.onClick(adapter.getItem(position),which);
                     }
                 }).grid().build();
                 break;

--- a/example/src/main/java/com/cocosw/bottomsheet/example/Main.java
+++ b/example/src/main/java/com/cocosw/bottomsheet/example/Main.java
@@ -33,7 +33,7 @@ public class Main extends ActionBarActivity implements AdapterView.OnItemClickLi
 
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        Intent intent = new Intent(this, ListAcitivty.class).setFlags(position).putExtra("title", adapter.getItem(position));
+        Intent intent = new Intent(this, ListActivity.class).setFlags(position).putExtra("title", adapter.getItem(position));
         if (position == 5) {
             intent.putExtra("style", true);
         }

--- a/library/src/main/java/com/cocosw/bottomsheet/BottomSheet.java
+++ b/library/src/main/java/com/cocosw/bottomsheet/BottomSheet.java
@@ -761,7 +761,7 @@ public class BottomSheet extends Dialog implements DialogInterface {
         }
 
         /**
-         * Set title for BottomSheet
+         * Set icon for BottomSheet
          * @param icon icon for BottomSheet
          * @return This Builder object to allow for chaining of calls to set methods
          */
@@ -771,7 +771,7 @@ public class BottomSheet extends Dialog implements DialogInterface {
         }
 
         /**
-         * Set title for BottomSheet
+         * Set icon for BottomSheet
          * @param iconRes icon resource id for BottomSheet
          * @return This Builder object to allow for chaining of calls to set methods
          */

--- a/library/src/main/java/com/cocosw/bottomsheet/BottomSheet.java
+++ b/library/src/main/java/com/cocosw/bottomsheet/BottomSheet.java
@@ -686,6 +686,20 @@ public class BottomSheet extends Dialog implements DialogInterface {
         }
 
         /**
+         * Find a menu item with the specified id
+         *
+         * @param id ID of item
+         * @return the menu item, or null if not found
+         */
+        private MenuItem findItem(int id) {
+            for (MenuItem item : menuItems) {
+                if (item.id == id)
+                    return item;
+            }
+            return null;
+        }
+
+        /**
          * Add one item into BottomSheet
          *
          * @param id ID of item
@@ -736,6 +750,32 @@ public class BottomSheet extends Dialog implements DialogInterface {
         }
 
         /**
+         * Set icon for an item in BottomSheet
+         * @param icon icon for BottomSheet
+         * @return This Builder object to allow for chaining of calls to set methods
+         */
+        public Builder icon(int id, @NonNull Drawable icon) {
+            MenuItem item = findItem(id);
+            if (item != null) {
+                item.icon = icon;
+            }
+            return this;
+        }
+
+        /**
+         * Set icon for an item in BottomSheet
+         * @param iconRes icon resource id for BottomSheet
+         * @return This Builder object to allow for chaining of calls to set methods
+         */
+        public Builder icon(int id, @DrawableRes int iconRes) {
+            MenuItem item = findItem(id);
+            if (item != null) {
+                item.icon = context.getResources().getDrawable(iconRes);
+            }
+            return this;
+        }
+
+        /**
          * Set title for BottomSheet
          * @param titleRes title for BottomSheet
          * @return This Builder object to allow for chaining of calls to set methods
@@ -751,11 +791,9 @@ public class BottomSheet extends Dialog implements DialogInterface {
          * @return This Builder object to allow for chaining of calls to set methods
          */
         public Builder remove(int id) {
-            for (MenuItem item : menuItems){
-                if (item.id == id) {
-                    menuItems.remove(item);
-                    break;
-                }
+            MenuItem item = findItem(id);
+            if (item != null) {
+                menuItems.remove(item);
             }
             return this;
         }


### PR DESCRIPTION
The use case for the additional methods is that we are switching to creating icons from SVGs, rendering to Drawable using the androidsvg library. This way, our designers don't have to export 3 or more different sizes of PNGs for each icon. We can't specify the svgs as resource ids, because they have to be rendered first, so we needed a way to set the drawables on the menu items after the menu has been expanded from xml.