### PR TITLE
Support optional id for divider items

### DIFF
--- a/library/src/main/java/com/cocosw/bottomsheet/BottomSheet.java
+++ b/library/src/main/java/com/cocosw/bottomsheet/BottomSheet.java
@@ -664,8 +664,14 @@ public class BottomSheet extends Dialog implements DialogInterface {
 
                             menuItems.add(item);
                         } else if (elemName.equals("divider")) {
+                            String resId = xpp.getAttributeValue("http://schemas.android.com/apk/res/android", "id");
+
                             MenuItem item = new MenuItem();
                             item.divider = true;
+                            if (!TextUtils.isEmpty(resId)) {
+                                item.id = Integer.valueOf(resId.replace("@", ""));
+                            }
+
                             menuItems.add(item);
                         }
                     }


### PR DESCRIPTION
I added an optional id for divider items. This allows dividers to be removed by calling `Builder.remove(int)`.

Use case: You have a large menu with many dividers. You remove some menu items using the builder depending on some application state, so it could happen that two or more dividers are drawn side by side. With this PR you could remove an menu item and it's associated divider by their ids.

PS: This is *not* tested yet. But it seems so trivial that I decided to just make a quick on-page proposal. I hope, this is ok!