### PR TITLE
Moved top divider view attributes to a style that can be overridden.

### DIFF
--- a/library/src/main/res/layout/bottom_sheet_dialog.xml
+++ b/library/src/main/res/layout/bottom_sheet_dialog.xml
@@ -14,7 +14,7 @@
         android:layout_gravity="bottom">
 
         <View
-            android:style="@style/BottomSheet.TopDivider" />
+            style="@style/BottomSheet.TopDivider" />
 
         <LinearLayout
             android:layout_width="fill_parent"

--- a/library/src/main/res/layout/bottom_sheet_dialog.xml
+++ b/library/src/main/res/layout/bottom_sheet_dialog.xml
@@ -3,8 +3,7 @@
 <com.cocosw.bottomsheet.ClosableSlidingLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    >
+    android:layout_height="wrap_content">
 
     <LinearLayout
         android:orientation="vertical"
@@ -13,11 +12,9 @@
         android:background="?bs_dialogBackground"
         tools:ignore="Overdraw"
         android:layout_gravity="bottom">
+
         <View
-            android:background="?bs_dividerColor"
-            android:layout_width="fill_parent"
-            android:layout_height="1dp"
-            android:layout_marginBottom="8dp"/>
+            android:style="@style/BottomSheet.TopDivider" />
 
         <LinearLayout
             android:layout_width="fill_parent"
@@ -31,15 +28,13 @@
                 android:visibility="gone"
                 tools:ignore="ContentDescription"
                 style="@style/BottomSheet.Icon" />
-            
+
             <TextView
                 android:id="@+id/bottom_sheet_title"
                 android:visibility="gone"
-                style="@style/BottomSheet.Title"
-                />
+                style="@style/BottomSheet.Title" />
             
         </LinearLayout>
-
 
         <GridView
             android:layout_width="match_parent"
@@ -48,7 +43,8 @@
             android:numColumns="?bs_numColumns"
             android:fadingEdge="none"
             style="?bs_listStyle"
-            tools:listitem="@layout/bs_grid_entry"
-            />
+            tools:listitem="@layout/bs_grid_entry" />
+
     </LinearLayout>
+
 </com.cocosw.bottomsheet.ClosableSlidingLayout>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -156,7 +156,11 @@
         <item name="android:windowExitAnimation">@anim/dock_bottom_exit</item>
     </style>
 
-
-
+    <style name="BottomSheet.TopDivider">
+        <item name="android:background">?bs_dividerColor</item>
+        <item name="android:layout_width">fill_parent</item>
+        <item name="android:layout_height">1dp</item>
+        <item name="android:layout_marginBottom">8dp</item>
+    </style>
 
 </resources>


### PR DESCRIPTION
I would like to remove the bottom margin on the top divider.  This pull request moves the top divider's attributes into a style so it can be overridden.

    <View
            android:background="?bs_dividerColor"
            android:layout_width="fill_parent"
            android:layout_height="1dp"
            android:layout_marginBottom="8dp"/>    <==

![bottom-sheet-margin](https://cloud.githubusercontent.com/assets/987532/6795930/5ece5a42-d1a6-11e4-8e90-8554a8e8b06b.png)