### PR TITLE
Fade bottom sheet in and out to match Android share intent's material design implementation

### DIFF
--- a/library/src/main/res/anim/dock_bottom_enter.xml
+++ b/library/src/main/res/anim/dock_bottom_enter.xml
@@ -21,4 +21,7 @@
         android:interpolator="@android:anim/decelerate_interpolator">
     <translate android:fromYDelta="100%" android:toYDelta="0"
         android:duration="250"/>
+	<alpha
+        android:fromAlpha="0.0" android:toAlpha="1.0"
+        android:duration="250"/>
 </set>

--- a/library/src/main/res/anim/dock_bottom_exit.xml
+++ b/library/src/main/res/anim/dock_bottom_exit.xml
@@ -21,4 +21,7 @@
         android:interpolator="@android:anim/accelerate_interpolator">
     <translate android:fromYDelta="0" android:toYDelta="100%"
         android:startOffset="100" android:duration="250"/>
+	<alpha
+        android:fromAlpha="1.0" android:toAlpha="0.0"
+        android:duration="250"/>
 </set>


### PR DESCRIPTION
This makes the bottom sheet entry and exit animations match the Lollipop share intent bottom sheet animation for consistency. I typically override these styles in my own apps, and might as well PR them.