### PR TITLE
follow Menu semantics when the item id does not exist

### DIFF
--- a/library/src/main/java/com/cocosw/bottomsheet/ActionMenu.java
+++ b/library/src/main/java/com/cocosw/bottomsheet/ActionMenu.java
@@ -184,7 +184,12 @@ class ActionMenu implements SupportMenu {
     }
 
     public MenuItem findItem(int id) {
-        return mItems.get(findItemIndex(id));
+        final int index = findItemIndex(id);
+        if (index < 0) {
+            return null;
+        }
+
+        return mItems.get(index);
     }
 
     public MenuItem getItem(int index) {
@@ -258,7 +263,12 @@ class ActionMenu implements SupportMenu {
     }
 
     public void removeItem(int id) {
-        mItems.remove(findItemIndex(id));
+        final int index = findItemIndex(id);
+        if (index < 0) {
+            return;
+        }
+
+        mItems.remove(index);
     }
 
     public void setGroupCheckable(int group, boolean checkable,


### PR DESCRIPTION
ActionMenu::findItem() and ActionMenu::removeItem() throw exceptions when the item id doesn't exist, so I wanted to bring behavior in line with Menu.