### PR TITLE
Reduce switch case clauses number of lines to increase the readability

### DIFF
--- a/example/src/main/java/com/cocosw/bottomsheet/example/ListAcitivty.java
+++ b/example/src/main/java/com/cocosw/bottomsheet/example/ListAcitivty.java
@@ -84,53 +84,22 @@ public class ListAcitivty extends AppCompatActivity implements AdapterView.OnIte
     protected Dialog onCreateDialog(final int position, Bundle args) {
         switch (action) {
             case 0:
-                sheet = new BottomSheet.Builder(this).icon(getRoundedBitmap(R.drawable.icon)).title("To " + adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position), which);
-                    }
-                }).build();
+                casePositionZero(position);
                 break;
             case 1:
-                sheet = new BottomSheet.Builder(this).sheet(R.menu.noicon).listener(new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position), which);
-                    }
-                }).build();
+               casePositionOne(position);
                 break;
-
             case 2:
-                sheet = new BottomSheet.Builder(this).darkTheme().title("To " + adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position), which);
-                    }
-                }).build();
+                casePositionTwo(position);
                 break;
             case 3:
-                sheet = new BottomSheet.Builder(this).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position), which);
-                    }
-                }).grid().build();
+               casePositionThree(position);
                 break;
             case 4:
-                sheet = new BottomSheet.Builder(this, R.style.BottomSheet_StyleDialog).title("To " + adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position), which);
-                    }
-                }).build();
+                casePositionFour(position);
                 break;
             case 5:
-                sheet = new BottomSheet.Builder(this).title("To " + adapter.getItem(position)).sheet(R.menu.longlist).listener(new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position), which);
-                    }
-                }).limit(R.integer.bs_initial_list_row).build();
+               casePositionFive(position);
                 break;
             case 6:
                 sheet = getShareActions("Hello " + adapter.getItem(position)).title("Share To " + adapter.getItem(position)).limit(R.integer.no_limit).build();
@@ -139,57 +108,119 @@ public class ListAcitivty extends AppCompatActivity implements AdapterView.OnIte
                 sheet = getShareActions("Hello " + adapter.getItem(position)).title("Share To " + adapter.getItem(position)).build();
                 break;
             case 8:
-                sheet = new BottomSheet.Builder(this).icon(getRoundedBitmap(R.drawable.icon)).title("To " + adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position), which);
-                    }
-                }).build();
-                final Menu menu = sheet.getMenu();
-                menu.getItem(0).setTitle("MenuClickListener");
-                menu.getItem(0).setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
-                    @Override
-                    public boolean onMenuItemClick(MenuItem item) {
-                        q.alert("OnMenuItemClickListener", "You can set OnMenuItemClickListener for each item");
-                        return true;
-                    }
-                });
-                menu.getItem(1).setVisible(false);
-                menu.getItem(2).setEnabled(false);
-                menu.add(Menu.NONE, 23, Menu.NONE, "Fresh meal!");
-                menu.findItem(23).setIcon(R.drawable.perm_group_user_dictionary);
-                menu.findItem(23).setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
-                    @Override
-                    public boolean onMenuItemClick(MenuItem item) {
-                        q.toast("Hello");
-                        return true;
-                    }
-                });
-                menu.setGroupVisible(android.R.id.empty,false);
+                casePositionEight(position);
                 break;
             case 9:
-                sheet = new BottomSheet.Builder(this, R.style.BottomSheet_CustomizedDialog).grid().title("To " + adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        ListAcitivty.this.onClick(adapter.getItem(position), which);
-                    }
-                }).build();
-                sheet.setOnShowListener(new DialogInterface.OnShowListener() {
-                    @Override
-                    public void onShow(DialogInterface dialog) {
-                        q.toast("I'm showing");
-                    }
-                });
-                sheet.setOnDismissListener(new DialogInterface.OnDismissListener() {
-                    @Override
-                    public void onDismiss(DialogInterface dialog) {
-                        q.toast("I'm dismissing");
-                    }
-                });
+                casePositionNine(position);
                 break;
 
         }
         return sheet;
+    }
+
+    private void casePositionNine(final int position) {
+        sheet = new BottomSheet.Builder(this, R.style.BottomSheet_CustomizedDialog).grid().title("To " + adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ListAcitivty.this.onClick(adapter.getItem(position), which);
+            }
+        }).build();
+        sheet.setOnShowListener(new DialogInterface.OnShowListener() {
+            @Override
+            public void onShow(DialogInterface dialog) {
+                q.toast("I'm showing");
+            }
+        });
+        sheet.setOnDismissListener(new DialogInterface.OnDismissListener() {
+            @Override
+            public void onDismiss(DialogInterface dialog) {
+                q.toast("I'm dismissing");
+            }
+        });
+    }
+
+    private void casePositionEight(final int position) {
+        sheet = new BottomSheet.Builder(this).icon(getRoundedBitmap(R.drawable.icon)).title("To " + adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ListAcitivty.this.onClick(adapter.getItem(position), which);
+            }
+        }).build();
+        final Menu menu = sheet.getMenu();
+        menu.getItem(0).setTitle("MenuClickListener");
+        menu.getItem(0).setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+                q.alert("OnMenuItemClickListener", "You can set OnMenuItemClickListener for each item");
+                return true;
+            }
+        });
+        menu.getItem(1).setVisible(false);
+        menu.getItem(2).setEnabled(false);
+        menu.add(Menu.NONE, 23, Menu.NONE, "Fresh meal!");
+        menu.findItem(23).setIcon(R.drawable.perm_group_user_dictionary);
+        menu.findItem(23).setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+            @Override
+            public boolean onMenuItemClick(MenuItem item) {
+                q.toast("Hello");
+                return true;
+            }
+        });
+        menu.setGroupVisible(android.R.id.empty,false);
+    }
+
+    private void casePositionFive(final int position) {
+        sheet = new BottomSheet.Builder(this).title("To " + adapter.getItem(position)).sheet(R.menu.longlist).listener(new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ListAcitivty.this.onClick(adapter.getItem(position), which);
+            }
+        }).limit(R.integer.bs_initial_list_row).build();
+    }
+
+    private void casePositionFour(final int position) {
+        sheet = new BottomSheet.Builder(this, R.style.BottomSheet_StyleDialog).title("To " + adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ListAcitivty.this.onClick(adapter.getItem(position), which);
+            }
+        }).build();
+    }
+
+    private void casePositionThree(final int position) {
+        sheet = new BottomSheet.Builder(this).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ListAcitivty.this.onClick(adapter.getItem(position), which);
+            }
+        }).grid().build();
+    }
+
+    private void casePositionTwo(final int position) {
+        sheet = new BottomSheet.Builder(this).darkTheme().title("To " + adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ListAcitivty.this.onClick(adapter.getItem(position), which);
+            }
+        }).build();
+    }
+
+    private void casePositionOne(final int position) {
+        sheet = new BottomSheet.Builder(this).sheet(R.menu.noicon).listener(new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ListAcitivty.this.onClick(adapter.getItem(position), which);
+            }
+        }).build();
+    }
+
+    private void casePositionZero(final int position) {
+        sheet = new BottomSheet.Builder(this).icon(getRoundedBitmap(R.drawable.icon)).title("To " + adapter.getItem(position)).sheet(R.menu.list).listener(new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ListAcitivty.this.onClick(adapter.getItem(position), which);
+            }
+        }).build();
     }
 
     private BottomSheet.Builder getShareActions(String text) {

--- a/library/src/main/java/com/cocosw/bottomsheet/SimpleSectionedGridAdapter.java
+++ b/library/src/main/java/com/cocosw/bottomsheet/SimpleSectionedGridAdapter.java
@@ -119,13 +119,7 @@ class SimpleSectionedGridAdapter extends BaseAdapter{
                 break;
 
             case GridView.STRETCH_SPACING:
-                mColumnWidth = requestedColumnWidth;
-                if (mNumColumns > 1) {
-                    mHorizontalSpacing = requestedHorizontalSpacing +
-                            spaceLeftOver / (mNumColumns - 1);
-                } else {
-                    mHorizontalSpacing = requestedHorizontalSpacing + spaceLeftOver;
-                }
+                caseGridViewStretchSpacing(spaceLeftOver);
                 break;
 
             case GridView.STRETCH_SPACING_UNIFORM:
@@ -136,6 +130,16 @@ class SimpleSectionedGridAdapter extends BaseAdapter{
         }
         mHeaderWidth = mWidth + ((mNumColumns - 1) * (mColumnWidth + mHorizontalSpacing)) ;
         return mHeaderWidth;
+    }
+
+    private void caseGridViewStretchSpacing(int spaceLeftOver) {
+        mColumnWidth = requestedColumnWidth;
+        if (mNumColumns > 1) {
+            mHorizontalSpacing = requestedHorizontalSpacing +
+                    spaceLeftOver / (mNumColumns - 1);
+        } else {
+            mHorizontalSpacing = requestedHorizontalSpacing + spaceLeftOver;
+        }
     }
 
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1151 - “ "switch case" clauses should not have too many lines”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1151
Please let me know if you have any questions.
Ayman Abdelghany.