### PR TITLE
Simplified local library install

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,21 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+    }
+}
+
 apply from: 'https://raw.githubusercontent.com/soarcn/gradle/master/android-library.gradle'
 apply from: 'https://raw.githubusercontent.com/soarcn/gradle/master/maven_push.gradle'
 
+apply plugin: 'com.github.dcendents.android-maven'
+
+
 dependencies {
     compile 'com.android.support:support-v4:22.2.0'
+
 }
 


### PR DESCRIPTION
This configuration update allows the command "gradle install".
The install command will install the library into the standard ~/.m2/repository directory instead of a custom directory.
